### PR TITLE
Propagate trivial destructibility and fix missing returns in static_vector.insert

### DIFF
--- a/Source.cpp
+++ b/Source.cpp
@@ -22,6 +22,7 @@ struct Test
 
 int main()
 {
+	static_assert(std::is_trivially_destructible_v<static_vector<int,3>>);
 	static_vector<std::string, 10> vec = { "Cristi", "e", "foarte", "tare" };
 
 	vec.insert(vec.cbegin() + 1, "nu");

--- a/Source.cpp
+++ b/Source.cpp
@@ -31,4 +31,11 @@ int main()
 	{
 		std::cout << word << ' ';
 	}
+	std::cout << "\n";
+
+	// test destructor
+	{
+	static_vector<Test, 3> destruct_test;
+	destruct_test.emplace_back();
+	}
 }

--- a/inc/static_vector.hpp
+++ b/inc/static_vector.hpp
@@ -826,31 +826,36 @@ public:
 		*pos = value;
 
 		_size++;
+
+		return pos;
 	}
 
 	constexpr iterator insert(const_iterator pos, const T& value)
 	{
-		if (_size == Capacity)
-		{
-			throw std::runtime_error("Vector is at full capacity, insertion not allowed!\n");
-		}
-
-		std::construct_at(std::to_address(end()), std::move(*(end() - 1)));
-
-		std::move_backward(pos, cend() - 1, end());
-
-		**reinterpret_cast<iterator*>(&pos) = value;
-
-		_size++;
+		auto mutable_pos = *reinterpret_cast<iterator*>(&pos);
+		return this->insert(mutable_pos, value);
 	}
 
+	// If T is trivially_destructible, static_vector<T> should be too.
+	// To get trivial destructibility, a class needs to default ~static_vector
+	// Use a requires clause to select the right version (default vs destroy_n)
+	//
+	// Citation--https://en.cppreference.com/w/cpp/language/destructor#Trivial_destructor
+	// See also
+	// - https://www.sandordargo.com/blog/2021/06/16/multiple-destructors-with-cpp-concepts
+	// - Sy Brand's talk "How to write well-behaved value wrappers",
+	//    https://youtu.be/sQcPte0JNmE?t=1147
+	//
+	// Unfortunately, this won't work on clang yet
+	constexpr ~static_vector() = default;
 	constexpr ~static_vector() noexcept (std::is_nothrow_destructible_v<T>)
+		requires(!std::is_trivially_destructible_v<T>)
 	{
-		if constexpr (!std::is_trivially_destructible_v<T>)
-		{
-			std::destroy_n(begin(), _size);
-		}
+		std::destroy_n(begin(), _size);
 	}
+
+	static_assert(std::is_trivially_destructible_v<T>
+			    ==std::is_trivially_destructible_v<T>);
 
 	constexpr std::size_t size() const noexcept
 	{


### PR DESCRIPTION
In order for static_vector<int.10> to be trivially destructible, we need to default its destructor. 
I wrote some C++20 code that will conditionally default the destructor when able and fall back to the delete_n implementation when necessary. 

Unfortunately, clang doesn't support this yet. However I think g++ and msvc do. There is an older way to do this that all the compilers will support, but it is a lot of boilerplate, so if you're ok with waiting for clang, and you don't want to support older standards, then this is the better solution imo. 

There were also return statements missing from insert. This crashed the tests on my machine, so i had them return the iterator.